### PR TITLE
model serializer

### DIFF
--- a/django_webhook/settings.py
+++ b/django_webhook/settings.py
@@ -20,4 +20,14 @@ def get_settings():
     if isinstance(encoder_cls, str):
         webhook_settings["PAYLOAD_ENCODER_CLASS"] = import_string(encoder_cls)
 
+    model_serializer = webhook_settings.get("MODEL_SERIALIZER")
+    if model_serializer and isinstance(model_serializer, str):
+        resolved_func = import_string(model_serializer)
+        if not callable(resolved_func):
+            raise ImportError(
+                "DJANGO_WEBHOOK['MODEL_SERIALIZER'] must be a callable that accepts a "
+                "Django model instance as its first argument."
+            )
+        webhook_settings["MODEL_SERIALIZER"] = resolved_func
+
     return webhook_settings

--- a/django_webhook/signals.py
+++ b/django_webhook/signals.py
@@ -43,11 +43,16 @@ class SignalListener:
 
         topic = f"{self.model_label}/{action_type}"
         webhook_ids = _find_webhooks(topic)
-        encoder_cls = get_settings()["PAYLOAD_ENCODER_CLASS"]
 
+        settings = get_settings()
+        encoder_cls = settings.get("PAYLOAD_ENCODER_CLASS", None)
+
+        model_serializer = settings.get("MODEL_SERIALIZER", model_dict)
+        object = model_serializer(instance) if instance is not None else None
+        
         for id, uuid in webhook_ids:
             payload_dict = dict(
-                object=model_dict(instance),
+                object=object,
                 topic=topic,
                 object_type=self.model_label,
                 webhook_uuid=str(uuid),
@@ -62,7 +67,10 @@ class SignalListener:
 
     def connect(self):
         self.signal.connect(
-            self.run, sender=self.model_cls, weak=False, dispatch_uid=self.uid  # type: ignore
+            self.run,
+            sender=self.model_cls,
+            weak=False,
+            dispatch_uid=self.uid,  # type: ignore
         )
 
     @property
@@ -86,7 +94,7 @@ def connect_signals():
         post_delete_listener.connect()
 
 
-def model_dict(model):
+def model_dict(model: models.Model) -> dict:
     """
     Returns the model instance as a dict, nested values for related models.
     """

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -21,6 +21,9 @@ from tests.model_data import TEST_JOIN_DATE, TEST_LAST_ACTIVE, TEST_USER
 from tests.models import Country, User
 
 
+from django.db import models
+
+
 pytestmark = pytest.mark.django_db
 
 
@@ -232,4 +235,44 @@ def test_signal_listener_uid():
             signal=post_delete, signal_name="post_delete", model_cls=Country
         ).uid
         == "django_webhook_tests.Country_post_delete"
+    )
+
+def custom_model_serializer(instance: models.Model) -> dict:
+    return {
+        "custom_id": instance.pk, 
+        "custom_name": getattr(instance, "name", "")
+    }
+
+
+def test_model_serializer(mocker):
+    mock_fire_webhook = mocker.patch("django_webhook.signals.fire_webhook")
+
+    webhook = WebhookFactory(
+        topics=[
+            WebhookTopicFactory(name="tests.Country/update"),
+        ],
+    )
+
+    country = Country.objects.create(name="Coruscant")
+
+    with override_settings(
+        DJANGO_WEBHOOK={"MODEL_SERIALIZER": "tests.test_signals.custom_model_serializer"}
+    ):
+        country.save()
+
+    mock_fire_webhook.delay.assert_called_once_with(
+        webhook.id,
+        json.dumps(
+            {
+                "object": {
+                    "custom_id": country.id, 
+                    "custom_name": "Coruscant"
+                },
+                "topic": "tests.Country/update",
+                "object_type": "tests.Country",
+                "webhook_uuid": str(webhook.uuid),
+            },
+        ),
+        topic="tests.Country/update",
+        object_type="tests.Country",
     )


### PR DESCRIPTION
This pull request adds support for customizing the serialization of Django model instances in webhook payloads by allowing a user-defined serializer function via the `MODEL_SERIALIZER` setting. It also includes refactoring and new tests to ensure correct behavior.
